### PR TITLE
Rebrand from eoscr to edenia for github org transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **A legitimate list of community backed quality BPs to vote for**
 
 
-![](https://img.shields.io/github/license/eoscostarica/eden-smart-proxy) ![](https://img.shields.io/badge/code%20style-standard-brightgreen.svg) ![](https://img.shields.io/badge/%E2%9C%93-collaborative_etiquette-brightgreen.svg) ![](https://img.shields.io/twitter/follow/eoscostarica.svg?style=social&logo=twitter) ![](https://img.shields.io/github/forks/eoscostarica/eden-smart-proxy?style=social)
+![](https://img.shields.io/github/license/edenia/eden-smart-proxy) ![](https://img.shields.io/badge/code%20style-standard-brightgreen.svg) ![](https://img.shields.io/badge/%E2%9C%93-collaborative_etiquette-brightgreen.svg) ![](https://img.shields.io/twitter/follow/edeniaWeb3.svg?style=social&logo=twitter) ![](https://img.shields.io/github/forks/edenia/eden-smart-proxy?style=social)
 
 
 The Eden Smart proxy is an app available only for eden on EOS members. The intention behind this project is to leverage the Eden democratic process to produce a legitimate list of community backed quality BPs to vote for. Eden members can delegate their vote to the eden smart proxy which then votes for the top 30 BPs according to a weighted calculation depending on members' election rank.
@@ -94,7 +94,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 
 Please read EOS Costa Rica's [Open Source Contributing Guidelines](https://developers.eoscostarica.io/docs/open-source-guidelines).
 
-Please report bugs big and small by [opening an issue](https://github.com/eoscostarica/eden-smart-proxy/issues/new/choose)
+Please report bugs big and small by [opening an issue](https://github.com/edenia/eden-smart-proxy/issues/new/choose)
 
 ## About Edenia
 

--- a/contracts/myvoteeosdao/include/myvoteeosdao/myvoteeosdao.hpp
+++ b/contracts/myvoteeosdao/include/myvoteeosdao/myvoteeosdao.hpp
@@ -2,7 +2,7 @@
 
 /*
  *
- * @author  EOSCostaRica.io [ https://eoscostarica.io ]
+ * @author  edenia.com [ https://edenia.com ]
  *
  * @section DESCRIPTION
  *  Header file for the declaration of all functions

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "edenia-website",
+  "name": "eden-smart-proxy",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/utils/meta.mk
+++ b/utils/meta.mk
@@ -3,8 +3,8 @@
 VERSION ?= $(shell git ls-files -s nginx.conf k8s public src package.json yarn.lock Dockerfile | git hash-object --stdin)
 
 IMAGE_NAME=website
-IMAGE_ID=$(shell docker images --format '{{.ID}}' --filter reference='docker.pkg.github.com/eoscostarica/eden-smart-proxy*latest')
-DOCKER_REGISTRY=docker.pkg.github.com/eoscostarica/eden-smart-proxy
+IMAGE_ID=$(shell docker images --format '{{.ID}}' --filter reference='docker.pkg.github.com/edenia/eden-smart-proxy*latest')
+DOCKER_REGISTRY=docker.pkg.github.com/edenia/eden-smart-proxy
 
 MAKE_ENV += DOCKER_REGISTRY VERSION IMAGE_NAME
 


### PR DESCRIPTION
Rebrand in order to prepare repo for transfer to edenia github org.